### PR TITLE
The "filename" option is required to use "extends" with "relative" paths

### DIFF
--- a/plugin/jade-templates.js
+++ b/plugin/jade-templates.js
@@ -29,6 +29,7 @@ function compile(file) {
     var output = content;
 
     try {
+        jadeOpts.filename = file.getPathInPackage();
         output = jade.compile(content, jadeOpts)();
         output = 'module.exports = { default: "' + clean(output) + '"};';
         // output = buildTemplate(output, moduleName);


### PR DESCRIPTION
https://github.com/pbastowski/meteor-jade-templates/issues/1
